### PR TITLE
Dependency Changes in torch library

### DIFF
--- a/examples/explainable_cnn_usage.ipynb
+++ b/examples/explainable_cnn_usage.ipynb
@@ -48,6 +48,7 @@
     "from explainable_cnn import CNNExplainer\n",
     "import pickle\n",
     "from torchvision import models\n",
+    "from torchvision.models import ResNet18_Weights\n",
     "import matplotlib.pyplot as plt"
    ]
   },
@@ -77,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = models.resnet18(weights=True)"
+    "model = models.resnet18(weights= ResNet18_Weights.DEFAULT)"
    ]
   },
   {

--- a/examples/explainable_cnn_usage.ipynb
+++ b/examples/explainable_cnn_usage.ipynb
@@ -77,7 +77,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "model = models.resnet18(pretrained=True)"
+    "model = models.resnet18(weights=True)"
    ]
   },
   {


### PR DESCRIPTION
UserWarning: The parameter 'pretrained' is deprecated since 0.13 and will be removed in 0.15, please use 'weights' instead.