### PR TITLE
Python 3.10 support

### DIFF
--- a/src/explainable_cnn/explainers/grad_cam.py
+++ b/src/explainable_cnn/explainers/grad_cam.py
@@ -1,4 +1,4 @@
-from collections import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import torch


### PR DESCRIPTION
Minor update to use abc from collections, as raw importing Sequence (and others) from collections since 3.10 is an error. Introduced in 3.3 and warned until 3.9.